### PR TITLE
chore: new version of openapi.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The InfluxDB v3 Management API Go client library lets you manage an InfluxDB Clo
 
 ## Generated types and API client
 
-This library is generated using [oapi-codegen](https://github.com/oapi-codegen/oapi-codegen) from this [OpenAPI spec](https://github.com/influxdata/docs-v2/blob/master/api-docs/cloud-dedicated/management/openapi.yml)
+This library is generated using [oapi-codegen](https://github.com/oapi-codegen/oapi-codegen) from this [OpenAPI spec](https://github.com/influxdata/docs-v2/blob/master/api-docs/influxdb3/cloud-dedicated/management/openapi.yml)
 
 ### Generate
 

--- a/client.gen.go
+++ b/client.gen.go
@@ -927,7 +927,7 @@ type GetClusterDatabasesResponse struct {
 		// Name The name of the cluster database
 		Name ClusterDatabaseName `json:"name"`
 
-		// PartitionTemplate A template for [partitioning](/influxdb/cloud-dedicated/admin/custom-partitions/) a cluster database.
+		// PartitionTemplate A template for [partitioning](/influxdb3/cloud-dedicated/admin/custom-partitions/) a cluster database.
 		//
 		// Each template part is evaluated in sequence, concatinating the final
 		// partition key from the output of each part, delimited by the partition
@@ -971,14 +971,14 @@ type GetClusterDatabasesResponse struct {
 		//   * `time=2023-01-01, a=<long string>`                   -> `2023|<long string>#|!|!`
 		//   * `time=2023-01-01, c=<long string>`                   -> `2023|!|!|<bucket ID for untruncated long string>`
 		//
-		// When using the default [partitioning](/influxdb/cloud-dedicated/admin/custom-partitions/) template (YYYY-MM-DD) there is no
+		// When using the default [partitioning](/influxdb3/cloud-dedicated/admin/custom-partitions/) template (YYYY-MM-DD) there is no
 		// encoding necessary, as the derived partition key contains a single part, and
 		// no reserved characters. [`TemplatePart::Bucket`] parts by definition will
 		// always be within the part length limit and contain no restricted characters
 		// so are also not percent-encoded and/or truncated.
 		PartitionTemplate *ClusterDatabasePartitionTemplate `json:"partitionTemplate,omitempty"`
 
-		// RetentionPeriod The retention period of the [cluster database](/influxdb/cloud-dedicated/admin/databases/) in nanoseconds, if applicable
+		// RetentionPeriod The retention period of the [cluster database](/influxdb3/cloud-dedicated/admin/databases/) in nanoseconds, if applicable
 		//
 		// If the retention period is not set or is set to 0, the database will have infinite retention
 		RetentionPeriod ClusterDatabaseRetentionPeriod `json:"retentionPeriod"`
@@ -1022,7 +1022,7 @@ type CreateClusterDatabaseResponse struct {
 		// Name The name of the cluster database
 		Name ClusterDatabaseName `json:"name"`
 
-		// PartitionTemplate A template for [partitioning](/influxdb/cloud-dedicated/admin/custom-partitions/) a cluster database.
+		// PartitionTemplate A template for [partitioning](/influxdb3/cloud-dedicated/admin/custom-partitions/) a cluster database.
 		//
 		// Each template part is evaluated in sequence, concatinating the final
 		// partition key from the output of each part, delimited by the partition
@@ -1066,14 +1066,14 @@ type CreateClusterDatabaseResponse struct {
 		//   * `time=2023-01-01, a=<long string>`                   -> `2023|<long string>#|!|!`
 		//   * `time=2023-01-01, c=<long string>`                   -> `2023|!|!|<bucket ID for untruncated long string>`
 		//
-		// When using the default [partitioning](/influxdb/cloud-dedicated/admin/custom-partitions/) template (YYYY-MM-DD) there is no
+		// When using the default [partitioning](/influxdb3/cloud-dedicated/admin/custom-partitions/) template (YYYY-MM-DD) there is no
 		// encoding necessary, as the derived partition key contains a single part, and
 		// no reserved characters. [`TemplatePart::Bucket`] parts by definition will
 		// always be within the part length limit and contain no restricted characters
 		// so are also not percent-encoded and/or truncated.
 		PartitionTemplate *ClusterDatabasePartitionTemplate `json:"partitionTemplate,omitempty"`
 
-		// RetentionPeriod The retention period of the [cluster database](/influxdb/cloud-dedicated/admin/databases/) in nanoseconds, if applicable
+		// RetentionPeriod The retention period of the [cluster database](/influxdb3/cloud-dedicated/admin/databases/) in nanoseconds, if applicable
 		//
 		// If the retention period is not set or is set to 0, the database will have infinite retention
 		RetentionPeriod ClusterDatabaseRetentionPeriod `json:"retentionPeriod"`
@@ -1144,7 +1144,7 @@ type UpdateClusterDatabaseResponse struct {
 		// Name The name of the cluster database
 		Name ClusterDatabaseName `json:"name"`
 
-		// RetentionPeriod The retention period of the [cluster database](/influxdb/cloud-dedicated/admin/databases/) in nanoseconds, if applicable
+		// RetentionPeriod The retention period of the [cluster database](/influxdb3/cloud-dedicated/admin/databases/) in nanoseconds, if applicable
 		//
 		// If the retention period is not set or is set to 0, the database will have infinite retention
 		RetentionPeriod ClusterDatabaseRetentionPeriod `json:"retentionPeriod"`
@@ -1182,10 +1182,10 @@ type CreateClusterDatabaseTableResponse struct {
 		// DatabaseName The name of the cluster database
 		DatabaseName ClusterDatabaseName `json:"databaseName"`
 
-		// Name The name of the [cluster database](/influxdb/cloud-dedicated/admin/databases/) table
+		// Name The name of the [cluster database](/influxdb3/cloud-dedicated/admin/databases/) table
 		Name ClusterDatabaseTableName `json:"name"`
 
-		// PartitionTemplate A template for [partitioning](/influxdb/cloud-dedicated/admin/custom-partitions/) a cluster database.
+		// PartitionTemplate A template for [partitioning](/influxdb3/cloud-dedicated/admin/custom-partitions/) a cluster database.
 		//
 		// Each template part is evaluated in sequence, concatinating the final
 		// partition key from the output of each part, delimited by the partition
@@ -1229,7 +1229,7 @@ type CreateClusterDatabaseTableResponse struct {
 		//   * `time=2023-01-01, a=<long string>`                   -> `2023|<long string>#|!|!`
 		//   * `time=2023-01-01, c=<long string>`                   -> `2023|!|!|<bucket ID for untruncated long string>`
 		//
-		// When using the default [partitioning](/influxdb/cloud-dedicated/admin/custom-partitions/) template (YYYY-MM-DD) there is no
+		// When using the default [partitioning](/influxdb3/cloud-dedicated/admin/custom-partitions/) template (YYYY-MM-DD) there is no
 		// encoding necessary, as the derived partition key contains a single part, and
 		// no reserved characters. [`TemplatePart::Bucket`] parts by definition will
 		// always be within the part length limit and contain no restricted characters
@@ -1272,7 +1272,7 @@ type GetDatabaseTokensResponse struct {
 		Description DatabaseTokenDescription `json:"description"`
 		Id          UuidV4                   `json:"id"`
 
-		// Permissions The list of permissions the [database token](/influxdb/cloud-dedicated/admin/tokens/database/) allows
+		// Permissions The list of permissions the [database token](/influxdb3/cloud-dedicated/admin/tokens/database/) allows
 		Permissions DatabaseTokenPermissions `json:"permissions"`
 	}
 	JSON400 *BadRequest
@@ -1314,7 +1314,7 @@ type CreateDatabaseTokenResponse struct {
 		Description DatabaseTokenDescription `json:"description"`
 		Id          UuidV4                   `json:"id"`
 
-		// Permissions The list of permissions the [database token](/influxdb/cloud-dedicated/admin/tokens/database/) allows
+		// Permissions The list of permissions the [database token](/influxdb3/cloud-dedicated/admin/tokens/database/) allows
 		Permissions DatabaseTokenPermissions `json:"permissions"`
 	}
 	JSON400 *BadRequest
@@ -1379,7 +1379,7 @@ type GetDatabaseTokenResponse struct {
 		Description DatabaseTokenDescription `json:"description"`
 		Id          UuidV4                   `json:"id"`
 
-		// Permissions The list of permissions the [database token](/influxdb/cloud-dedicated/admin/tokens/database/) allows
+		// Permissions The list of permissions the [database token](/influxdb3/cloud-dedicated/admin/tokens/database/) allows
 		Permissions DatabaseTokenPermissions `json:"permissions"`
 	}
 	JSON400 *BadRequest
@@ -1417,7 +1417,7 @@ type UpdateDatabaseTokenResponse struct {
 		Description DatabaseTokenDescription `json:"description"`
 		Id          UuidV4                   `json:"id"`
 
-		// Permissions The list of permissions the [database token](/influxdb/cloud-dedicated/admin/tokens/database/) allows
+		// Permissions The list of permissions the [database token](/influxdb3/cloud-dedicated/admin/tokens/database/) allows
 		Permissions DatabaseTokenPermissions `json:"permissions"`
 	}
 	JSON400 *BadRequest
@@ -1602,7 +1602,7 @@ func ParseGetClusterDatabasesResponse(rsp *http.Response) (*GetClusterDatabasesR
 			// Name The name of the cluster database
 			Name ClusterDatabaseName `json:"name"`
 
-			// PartitionTemplate A template for [partitioning](/influxdb/cloud-dedicated/admin/custom-partitions/) a cluster database.
+			// PartitionTemplate A template for [partitioning](/influxdb3/cloud-dedicated/admin/custom-partitions/) a cluster database.
 			//
 			// Each template part is evaluated in sequence, concatinating the final
 			// partition key from the output of each part, delimited by the partition
@@ -1646,14 +1646,14 @@ func ParseGetClusterDatabasesResponse(rsp *http.Response) (*GetClusterDatabasesR
 			//   * `time=2023-01-01, a=<long string>`                   -> `2023|<long string>#|!|!`
 			//   * `time=2023-01-01, c=<long string>`                   -> `2023|!|!|<bucket ID for untruncated long string>`
 			//
-			// When using the default [partitioning](/influxdb/cloud-dedicated/admin/custom-partitions/) template (YYYY-MM-DD) there is no
+			// When using the default [partitioning](/influxdb3/cloud-dedicated/admin/custom-partitions/) template (YYYY-MM-DD) there is no
 			// encoding necessary, as the derived partition key contains a single part, and
 			// no reserved characters. [`TemplatePart::Bucket`] parts by definition will
 			// always be within the part length limit and contain no restricted characters
 			// so are also not percent-encoded and/or truncated.
 			PartitionTemplate *ClusterDatabasePartitionTemplate `json:"partitionTemplate,omitempty"`
 
-			// RetentionPeriod The retention period of the [cluster database](/influxdb/cloud-dedicated/admin/databases/) in nanoseconds, if applicable
+			// RetentionPeriod The retention period of the [cluster database](/influxdb3/cloud-dedicated/admin/databases/) in nanoseconds, if applicable
 			//
 			// If the retention period is not set or is set to 0, the database will have infinite retention
 			RetentionPeriod ClusterDatabaseRetentionPeriod `json:"retentionPeriod"`
@@ -1731,7 +1731,7 @@ func ParseCreateClusterDatabaseResponse(rsp *http.Response) (*CreateClusterDatab
 			// Name The name of the cluster database
 			Name ClusterDatabaseName `json:"name"`
 
-			// PartitionTemplate A template for [partitioning](/influxdb/cloud-dedicated/admin/custom-partitions/) a cluster database.
+			// PartitionTemplate A template for [partitioning](/influxdb3/cloud-dedicated/admin/custom-partitions/) a cluster database.
 			//
 			// Each template part is evaluated in sequence, concatinating the final
 			// partition key from the output of each part, delimited by the partition
@@ -1775,14 +1775,14 @@ func ParseCreateClusterDatabaseResponse(rsp *http.Response) (*CreateClusterDatab
 			//   * `time=2023-01-01, a=<long string>`                   -> `2023|<long string>#|!|!`
 			//   * `time=2023-01-01, c=<long string>`                   -> `2023|!|!|<bucket ID for untruncated long string>`
 			//
-			// When using the default [partitioning](/influxdb/cloud-dedicated/admin/custom-partitions/) template (YYYY-MM-DD) there is no
+			// When using the default [partitioning](/influxdb3/cloud-dedicated/admin/custom-partitions/) template (YYYY-MM-DD) there is no
 			// encoding necessary, as the derived partition key contains a single part, and
 			// no reserved characters. [`TemplatePart::Bucket`] parts by definition will
 			// always be within the part length limit and contain no restricted characters
 			// so are also not percent-encoded and/or truncated.
 			PartitionTemplate *ClusterDatabasePartitionTemplate `json:"partitionTemplate,omitempty"`
 
-			// RetentionPeriod The retention period of the [cluster database](/influxdb/cloud-dedicated/admin/databases/) in nanoseconds, if applicable
+			// RetentionPeriod The retention period of the [cluster database](/influxdb3/cloud-dedicated/admin/databases/) in nanoseconds, if applicable
 			//
 			// If the retention period is not set or is set to 0, the database will have infinite retention
 			RetentionPeriod ClusterDatabaseRetentionPeriod `json:"retentionPeriod"`
@@ -1921,7 +1921,7 @@ func ParseUpdateClusterDatabaseResponse(rsp *http.Response) (*UpdateClusterDatab
 			// Name The name of the cluster database
 			Name ClusterDatabaseName `json:"name"`
 
-			// RetentionPeriod The retention period of the [cluster database](/influxdb/cloud-dedicated/admin/databases/) in nanoseconds, if applicable
+			// RetentionPeriod The retention period of the [cluster database](/influxdb3/cloud-dedicated/admin/databases/) in nanoseconds, if applicable
 			//
 			// If the retention period is not set or is set to 0, the database will have infinite retention
 			RetentionPeriod ClusterDatabaseRetentionPeriod `json:"retentionPeriod"`
@@ -1993,10 +1993,10 @@ func ParseCreateClusterDatabaseTableResponse(rsp *http.Response) (*CreateCluster
 			// DatabaseName The name of the cluster database
 			DatabaseName ClusterDatabaseName `json:"databaseName"`
 
-			// Name The name of the [cluster database](/influxdb/cloud-dedicated/admin/databases/) table
+			// Name The name of the [cluster database](/influxdb3/cloud-dedicated/admin/databases/) table
 			Name ClusterDatabaseTableName `json:"name"`
 
-			// PartitionTemplate A template for [partitioning](/influxdb/cloud-dedicated/admin/custom-partitions/) a cluster database.
+			// PartitionTemplate A template for [partitioning](/influxdb3/cloud-dedicated/admin/custom-partitions/) a cluster database.
 			//
 			// Each template part is evaluated in sequence, concatinating the final
 			// partition key from the output of each part, delimited by the partition
@@ -2040,7 +2040,7 @@ func ParseCreateClusterDatabaseTableResponse(rsp *http.Response) (*CreateCluster
 			//   * `time=2023-01-01, a=<long string>`                   -> `2023|<long string>#|!|!`
 			//   * `time=2023-01-01, c=<long string>`                   -> `2023|!|!|<bucket ID for untruncated long string>`
 			//
-			// When using the default [partitioning](/influxdb/cloud-dedicated/admin/custom-partitions/) template (YYYY-MM-DD) there is no
+			// When using the default [partitioning](/influxdb3/cloud-dedicated/admin/custom-partitions/) template (YYYY-MM-DD) there is no
 			// encoding necessary, as the derived partition key contains a single part, and
 			// no reserved characters. [`TemplatePart::Bucket`] parts by definition will
 			// always be within the part length limit and contain no restricted characters
@@ -2123,7 +2123,7 @@ func ParseGetDatabaseTokensResponse(rsp *http.Response) (*GetDatabaseTokensRespo
 			Description DatabaseTokenDescription `json:"description"`
 			Id          UuidV4                   `json:"id"`
 
-			// Permissions The list of permissions the [database token](/influxdb/cloud-dedicated/admin/tokens/database/) allows
+			// Permissions The list of permissions the [database token](/influxdb3/cloud-dedicated/admin/tokens/database/) allows
 			Permissions DatabaseTokenPermissions `json:"permissions"`
 		}
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
@@ -2199,7 +2199,7 @@ func ParseCreateDatabaseTokenResponse(rsp *http.Response) (*CreateDatabaseTokenR
 			Description DatabaseTokenDescription `json:"description"`
 			Id          UuidV4                   `json:"id"`
 
-			// Permissions The list of permissions the [database token](/influxdb/cloud-dedicated/admin/tokens/database/) allows
+			// Permissions The list of permissions the [database token](/influxdb3/cloud-dedicated/admin/tokens/database/) allows
 			Permissions DatabaseTokenPermissions `json:"permissions"`
 		}
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
@@ -2332,7 +2332,7 @@ func ParseGetDatabaseTokenResponse(rsp *http.Response) (*GetDatabaseTokenRespons
 			Description DatabaseTokenDescription `json:"description"`
 			Id          UuidV4                   `json:"id"`
 
-			// Permissions The list of permissions the [database token](/influxdb/cloud-dedicated/admin/tokens/database/) allows
+			// Permissions The list of permissions the [database token](/influxdb3/cloud-dedicated/admin/tokens/database/) allows
 			Permissions DatabaseTokenPermissions `json:"permissions"`
 		}
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
@@ -2404,7 +2404,7 @@ func ParseUpdateDatabaseTokenResponse(rsp *http.Response) (*UpdateDatabaseTokenR
 			Description DatabaseTokenDescription `json:"description"`
 			Id          UuidV4                   `json:"id"`
 
-			// Permissions The list of permissions the [database token](/influxdb/cloud-dedicated/admin/tokens/database/) allows
+			// Permissions The list of permissions the [database token](/influxdb3/cloud-dedicated/admin/tokens/database/) allows
 			Permissions DatabaseTokenPermissions `json:"permissions"`
 		}
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {

--- a/openapi.yml
+++ b/openapi.yml
@@ -1,26 +1,29 @@
 openapi: 3.1.0
 info:
-  title: InfluxDB Cloud Dedicated Management API
+  title: InfluxDB 3 Cloud Dedicated Management API
   description: |
-    The InfluxDB v3 Management API lets you manage an InfluxDB Cloud Dedicated instance and integrate functions such as creating and managing databases, permissions, and tokens into your workflow or application.
+    The Management API for InfluxDB 3 Cloud Dedicated provides a programmatic interface for managing a Cloud Dedicated cluster.
+    The Management API lets you integrate functions such as creating and managing databases, permissions, and tokens into your workflow or application.
 
     This documentation is generated from the
     InfluxDB OpenAPI specification.
-  summary: |
-    The Management API for InfluxDB Cloud Dedicated provides a programmatic interface for managing an InfluxDB Cloud Dedicated instance.
   license:
     name: MIT
     url: https://opensource.org/licenses/MIT
   version: ''
+  contact:
+    name: InfluxData
+    url: https://www.influxdata.com
+    email: support@influxdata.com
 servers:
   - url: https://{baseurl}/api/v0
-    description: InfluxDB Cloud Dedicated Management API URL
+    description: InfluxDB 3 Cloud Dedicated Management API URL
     variables:
       baseurl:
         enum:
           - console.influxdata.com
         default: console.influxdata.com
-        description: InfluxDB Cloud Dedicated Console URL
+        description: InfluxDB 3 Cloud Dedicated Console URL
 security:
   - bearerAuthManagementToken: []
     bearerAuthJwt: []
@@ -30,15 +33,13 @@ tags:
     description: |
       The InfluxDB Management API endpoints require the following credentials:
 
-      - `ACCOUNT_ID`: The ID of the [account](/influxdb/cloud-dedicated/get-started/setup/#request-an-influxdb-cloud-dedicated-cluster) that the cluster belongs to. To view account ID and cluster ID, [list cluster details](/influxdb/cloud-dedicated/admin/clusters/list/#detailed-output-in-json).
-      - `CLUSTER_ID`: The ID of the [cluster](/influxdb/cloud-dedicated/get-started/setup/#request-an-influxdb-cloud-dedicated-cluster) that you want to manage. To view account ID and cluster ID, [list cluster details](/influxdb/cloud-dedicated/admin/clusters/list/#detailed-output-in-json).
-      - `Authorization MANAGEMENT_TOKEN`: the `Authorization` HTTP header with a [management token](/influxdb/cloud-dedicated/admin/tokens/management/).
+      - `ACCOUNT_ID`: The ID of the [account](/influxdb3/cloud-dedicated/get-started/setup/#request-an-influxdb-cloud-dedicated-cluster) that the cluster belongs to. To view account ID and cluster ID, [list cluster details](/influxdb3/cloud-dedicated/admin/clusters/list/#detailed-output-in-json).
+      - `CLUSTER_ID`: The ID of the [cluster](/influxdb3/cloud-dedicated/get-started/setup/#request-an-influxdb-cloud-dedicated-cluster) that you want to manage. To view account ID and cluster ID, [list cluster details](/influxdb3/cloud-dedicated/admin/clusters/list/#detailed-output-in-json).
+      - `Authorization MANAGEMENT_TOKEN`: the `Authorization` HTTP header with a [management token](/influxdb3/cloud-dedicated/admin/tokens/management/).
 
-        See how to [create a management token](/influxdb/cloud-dedicated/admin/tokens/management/).
+        See how to [create a management token](/influxdb3/cloud-dedicated/admin/tokens/management/).
 
-        By default, management tokens in InfluxDB v3 are short-lived tokens issued by an OAuth2 identity provider that grant a specific user administrative access to your InfluxDB cluster. However, for automation purposes, you can manually create management tokens that authenticate directly with your InfluxDB cluster and do not require human interaction with your identity provider.
-
-
+        By default, management tokens in InfluxDB 3 are short-lived tokens issued by an OAuth2 identity provider that grant a specific user administrative access to your InfluxDB cluster. However, for automation purposes, you can manually create management tokens that authenticate directly with your InfluxDB cluster and do not require human interaction with your identity provider.
   - name: Database tokens
     description: Manage database read/write tokens for a cluster
   - name: Databases
@@ -299,13 +300,13 @@ paths:
       parameters:
         - name: accountId
           in: path
-          description: The ID of the [account](/influxdb/cloud-dedicated/get-started/setup/#request-an-influxdb-cloud-dedicated-cluster) to get the [databases](/influxdb/cloud-dedicated/admin/databases/) for
+          description: The ID of the [account](/influxdb3/cloud-dedicated/get-started/setup/#request-an-influxdb-cloud-dedicated-cluster) to get the [databases](/influxdb3/cloud-dedicated/admin/databases/) for
           required: true
           schema:
             $ref: '#/components/schemas/UuidV4'
         - name: clusterId
           in: path
-          description: The ID of the cluster to get the [databases](/influxdb/cloud-dedicated/admin/databases/) for
+          description: The ID of the cluster to get the [databases](/influxdb3/cloud-dedicated/admin/databases/) for
           required: true
           schema:
             $ref: '#/components/schemas/UuidV4'
@@ -320,7 +321,7 @@ paths:
                   type: object
                   properties:
                     accountId:
-                      description: The ID of the [account](/influxdb/cloud-dedicated/get-started/setup/#request-an-influxdb-cloud-dedicated-cluster) that the database belongs to
+                      description: The ID of the [account](/influxdb3/cloud-dedicated/get-started/setup/#request-an-influxdb-cloud-dedicated-cluster) that the database belongs to
                       $ref: '#/components/schemas/UuidV4'
                     clusterId:
                       description: The ID of the cluster that the database belongs to
@@ -401,7 +402,7 @@ paths:
       parameters:
         - name: accountId
           in: path
-          description: The ID of the [account](/influxdb/cloud-dedicated/get-started/setup/#request-an-influxdb-cloud-dedicated-cluster) to create the database for
+          description: The ID of the [account](/influxdb3/cloud-dedicated/get-started/setup/#request-an-influxdb-cloud-dedicated-cluster) to create the database for
           required: true
           schema:
             $ref: '#/components/schemas/UuidV4'
@@ -462,7 +463,7 @@ paths:
                 type: object
                 properties:
                   accountId:
-                    description: The ID of the [account](/influxdb/cloud-dedicated/get-started/setup/#request-an-influxdb-cloud-dedicated-cluster) that the database belongs to
+                    description: The ID of the [account](/influxdb3/cloud-dedicated/get-started/setup/#request-an-influxdb-cloud-dedicated-cluster) that the database belongs to
                     $ref: '#/components/schemas/UuidV4'
                   clusterId:
                     description: The ID of the cluster that the database belongs to
@@ -571,7 +572,7 @@ paths:
       parameters:
         - name: accountId
           in: path
-          description: The ID of the [account](/influxdb/cloud-dedicated/get-started/setup/#request-an-influxdb-cloud-dedicated-cluster) that the database belongs to
+          description: The ID of the [account](/influxdb3/cloud-dedicated/get-started/setup/#request-an-influxdb-cloud-dedicated-cluster) that the database belongs to
           required: true
           schema:
             $ref: '#/components/schemas/UuidV4'
@@ -629,7 +630,7 @@ paths:
                 type: object
                 properties:
                   accountId:
-                    description: The ID of the [account](/influxdb/cloud-dedicated/get-started/setup/#request-an-influxdb-cloud-dedicated-cluster) that the database belongs to
+                    description: The ID of the [account](/influxdb3/cloud-dedicated/get-started/setup/#request-an-influxdb-cloud-dedicated-cluster) that the database belongs to
                     $ref: '#/components/schemas/UuidV4'
                   clusterId:
                     description: The ID of the cluster that the database belongs to
@@ -727,7 +728,7 @@ paths:
       parameters:
         - name: accountId
           in: path
-          description: The ID of the [account](/influxdb/cloud-dedicated/get-started/setup/#request-an-influxdb-cloud-dedicated-cluster) that the database belongs to
+          description: The ID of the [account](/influxdb3/cloud-dedicated/get-started/setup/#request-an-influxdb-cloud-dedicated-cluster) that the database belongs to
           required: true
           schema:
             $ref: '#/components/schemas/UuidV4'
@@ -783,7 +784,7 @@ paths:
       parameters:
         - name: accountId
           in: path
-          description: The ID of the [account](/influxdb/cloud-dedicated/get-started/setup/#request-an-influxdb-cloud-dedicated-cluster) to create the database table for
+          description: The ID of the [account](/influxdb3/cloud-dedicated/get-started/setup/#request-an-influxdb-cloud-dedicated-cluster) to create the database table for
           required: true
           schema:
             $ref: '#/components/schemas/UuidV4'
@@ -841,7 +842,7 @@ paths:
                 type: object
                 properties:
                   accountId:
-                    description: The ID of the [account](/influxdb/cloud-dedicated/get-started/setup/#request-an-influxdb-cloud-dedicated-cluster) that the database table belongs to
+                    description: The ID of the [account](/influxdb3/cloud-dedicated/get-started/setup/#request-an-influxdb-cloud-dedicated-cluster) that the database table belongs to
                     $ref: '#/components/schemas/UuidV4'
                   clusterId:
                     description: The ID of the cluster that the database table belongs to
@@ -906,13 +907,13 @@ paths:
       parameters:
         - name: accountId
           in: path
-          description: The ID of the [account](/influxdb/cloud-dedicated/get-started/setup/#request-an-influxdb-cloud-dedicated-cluster) to get the [database tokens](/influxdb/cloud-dedicated/admin/tokens/database/) for
+          description: The ID of the [account](/influxdb3/cloud-dedicated/get-started/setup/#request-an-influxdb-cloud-dedicated-cluster) to get the [database tokens](/influxdb3/cloud-dedicated/admin/tokens/database/) for
           required: true
           schema:
             $ref: '#/components/schemas/UuidV4'
         - name: clusterId
           in: path
-          description: The ID of the cluster to get the [database tokens](/influxdb/cloud-dedicated/admin/tokens/database/) for
+          description: The ID of the cluster to get the [database tokens](/influxdb3/cloud-dedicated/admin/tokens/database/) for
           required: true
           schema:
             $ref: '#/components/schemas/UuidV4'
@@ -927,10 +928,10 @@ paths:
                   type: object
                   properties:
                     accountId:
-                      description: The ID of the [account](/influxdb/cloud-dedicated/get-started/setup/#request-an-influxdb-cloud-dedicated-cluster) that the [database token](/influxdb/cloud-dedicated/admin/tokens/database/) belongs to
+                      description: The ID of the [account](/influxdb3/cloud-dedicated/get-started/setup/#request-an-influxdb-cloud-dedicated-cluster) that the [database token](/influxdb3/cloud-dedicated/admin/tokens/database/) belongs to
                       $ref: '#/components/schemas/UuidV4'
                     clusterId:
-                      description: The ID of the cluster that the [database token](/influxdb/cloud-dedicated/admin/tokens/database/) belongs to
+                      description: The ID of the cluster that the [database token](/influxdb3/cloud-dedicated/admin/tokens/database/) belongs to
                       $ref: '#/components/schemas/UuidV4'
                     id:
                       description: The ID of the database token
@@ -1004,7 +1005,7 @@ paths:
       tags:
         - Database tokens
       description: |
-        Create a [database token](/influxdb/cloud-dedicated/admin/tokens/database/) for a cluster.
+        Create a [database token](/influxdb3/cloud-dedicated/admin/tokens/database/) for a cluster.
 
         The token returned on the `accessToken` property in the response can be used to authenticate query and write requests to the cluster.
 
@@ -1019,18 +1020,17 @@ paths:
         We recommend storing database tokens in a **secure secret store**.
         For example, see how to [authenticate Telegraf using tokens in your OS secret store](https://github.com/influxdata/telegraf/tree/master/plugins/secretstores/os).
 
-        If you lose a token, [delete the token from InfluxDB](/influxdb/cloud-dedicated/admin/tokens/database/delete/) and create a new one.
-
+        If you lose a token, [delete the token from InfluxDB](/influxdb3/cloud-dedicated/admin/tokens/database/delete/) and create a new one.
       parameters:
         - name: accountId
           in: path
-          description: The ID of the [account](/influxdb/cloud-dedicated/get-started/setup/#request-an-influxdb-cloud-dedicated-cluster) to create the [database token](/influxdb/cloud-dedicated/admin/tokens/database/) for
+          description: The ID of the [account](/influxdb3/cloud-dedicated/get-started/setup/#request-an-influxdb-cloud-dedicated-cluster) to create the [database token](/influxdb3/cloud-dedicated/admin/tokens/database/) for
           required: true
           schema:
             $ref: '#/components/schemas/UuidV4'
         - name: clusterId
           in: path
-          description: The ID of the cluster to create the [database token](/influxdb/cloud-dedicated/admin/tokens/database/) for
+          description: The ID of the cluster to create the [database token](/influxdb3/cloud-dedicated/admin/tokens/database/) for
           required: true
           schema:
             $ref: '#/components/schemas/UuidV4'
@@ -1078,10 +1078,10 @@ paths:
                 type: object
                 properties:
                   accountId:
-                    description: The ID of the [account](/influxdb/cloud-dedicated/get-started/setup/#request-an-influxdb-cloud-dedicated-cluster) that the [database token](/influxdb/cloud-dedicated/admin/tokens/database/) belongs to
+                    description: The ID of the [account](/influxdb3/cloud-dedicated/get-started/setup/#request-an-influxdb-cloud-dedicated-cluster) that the [database token](/influxdb3/cloud-dedicated/admin/tokens/database/) belongs to
                     $ref: '#/components/schemas/UuidV4'
                   clusterId:
-                    description: The ID of the cluster that the [database token](/influxdb/cloud-dedicated/admin/tokens/database/) belongs to
+                    description: The ID of the cluster that the [database token](/influxdb3/cloud-dedicated/admin/tokens/database/) belongs to
                     $ref: '#/components/schemas/UuidV4'
                   id:
                     description: The ID of the database token
@@ -1190,19 +1190,19 @@ paths:
       parameters:
         - name: accountId
           in: path
-          description: The ID of the [account](/influxdb/cloud-dedicated/get-started/setup/#request-an-influxdb-cloud-dedicated-cluster) that the [database token](/influxdb/cloud-dedicated/admin/tokens/database/) belongs to
+          description: The ID of the [account](/influxdb3/cloud-dedicated/get-started/setup/#request-an-influxdb-cloud-dedicated-cluster) that the [database token](/influxdb3/cloud-dedicated/admin/tokens/database/) belongs to
           required: true
           schema:
             $ref: '#/components/schemas/UuidV4'
         - name: clusterId
           in: path
-          description: The ID of the cluster that the [database token](/influxdb/cloud-dedicated/admin/tokens/database/) belongs to
+          description: The ID of the cluster that the [database token](/influxdb3/cloud-dedicated/admin/tokens/database/) belongs to
           required: true
           schema:
             $ref: '#/components/schemas/UuidV4'
         - name: tokenId
           in: path
-          description: The ID of the [database token](/influxdb/cloud-dedicated/admin/tokens/database/) to get
+          description: The ID of the [database token](/influxdb3/cloud-dedicated/admin/tokens/database/) to get
           required: true
           schema:
             $ref: '#/components/schemas/UuidV4'
@@ -1215,10 +1215,10 @@ paths:
                 type: object
                 properties:
                   accountId:
-                    description: The ID of the [account](/influxdb/cloud-dedicated/get-started/setup/#request-an-influxdb-cloud-dedicated-cluster) that the [database token](/influxdb/cloud-dedicated/admin/tokens/database/) belongs to
+                    description: The ID of the [account](/influxdb3/cloud-dedicated/get-started/setup/#request-an-influxdb-cloud-dedicated-cluster) that the [database token](/influxdb3/cloud-dedicated/admin/tokens/database/) belongs to
                     $ref: '#/components/schemas/UuidV4'
                   clusterId:
-                    description: The ID of the cluster that the [database token](/influxdb/cloud-dedicated/admin/tokens/database/) belongs to
+                    description: The ID of the cluster that the [database token](/influxdb3/cloud-dedicated/admin/tokens/database/) belongs to
                     $ref: '#/components/schemas/UuidV4'
                   id:
                     description: The ID of the database token
@@ -1304,19 +1304,19 @@ paths:
       parameters:
         - name: accountId
           in: path
-          description: The ID of the [account](/influxdb/cloud-dedicated/get-started/setup/#request-an-influxdb-cloud-dedicated-cluster) that the [database token](/influxdb/cloud-dedicated/admin/tokens/database/) belongs to
+          description: The ID of the [account](/influxdb3/cloud-dedicated/get-started/setup/#request-an-influxdb-cloud-dedicated-cluster) that the [database token](/influxdb3/cloud-dedicated/admin/tokens/database/) belongs to
           required: true
           schema:
             $ref: '#/components/schemas/UuidV4'
         - name: clusterId
           in: path
-          description: The ID of the cluster that the [database token](/influxdb/cloud-dedicated/admin/tokens/database/) belongs to
+          description: The ID of the cluster that the [database token](/influxdb3/cloud-dedicated/admin/tokens/database/) belongs to
           required: true
           schema:
             $ref: '#/components/schemas/UuidV4'
         - name: tokenId
           in: path
-          description: The ID of the [database token](/influxdb/cloud-dedicated/admin/tokens/database/) to update
+          description: The ID of the [database token](/influxdb3/cloud-dedicated/admin/tokens/database/) to update
           required: true
           schema:
             $ref: '#/components/schemas/UuidV4'
@@ -1371,10 +1371,10 @@ paths:
                 type: object
                 properties:
                   accountId:
-                    description: The ID of the [account](/influxdb/cloud-dedicated/get-started/setup/#request-an-influxdb-cloud-dedicated-cluster) that the [database token](/influxdb/cloud-dedicated/admin/tokens/database/) belongs to
+                    description: The ID of the [account](/influxdb3/cloud-dedicated/get-started/setup/#request-an-influxdb-cloud-dedicated-cluster) that the [database token](/influxdb3/cloud-dedicated/admin/tokens/database/) belongs to
                     $ref: '#/components/schemas/UuidV4'
                   clusterId:
-                    description: The ID of the cluster that the [database token](/influxdb/cloud-dedicated/admin/tokens/database/) belongs to
+                    description: The ID of the cluster that the [database token](/influxdb3/cloud-dedicated/admin/tokens/database/) belongs to
                     $ref: '#/components/schemas/UuidV4'
                   id:
                     description: The ID of the database token
@@ -1500,19 +1500,19 @@ paths:
       parameters:
         - name: accountId
           in: path
-          description: The ID of the [account](/influxdb/cloud-dedicated/get-started/setup/#request-an-influxdb-cloud-dedicated-cluster) that the [database token](/influxdb/cloud-dedicated/admin/tokens/database/) belongs to
+          description: The ID of the [account](/influxdb3/cloud-dedicated/get-started/setup/#request-an-influxdb-cloud-dedicated-cluster) that the [database token](/influxdb3/cloud-dedicated/admin/tokens/database/) belongs to
           required: true
           schema:
             $ref: '#/components/schemas/UuidV4'
         - name: clusterId
           in: path
-          description: The ID of the cluster that the [database token](/influxdb/cloud-dedicated/admin/tokens/database/) belongs to
+          description: The ID of the cluster that the [database token](/influxdb3/cloud-dedicated/admin/tokens/database/) belongs to
           required: true
           schema:
             $ref: '#/components/schemas/UuidV4'
         - name: tokenId
           in: path
-          description: The ID of the [database token](/influxdb/cloud-dedicated/admin/tokens/database/) to delete
+          description: The ID of the [database token](/influxdb3/cloud-dedicated/admin/tokens/database/) to delete
           required: true
           schema:
             $ref: '#/components/schemas/UuidV4'
@@ -1593,7 +1593,7 @@ components:
       minLength: 1
     ClusterDatabaseRetentionPeriod:
       description: |
-        The retention period of the [cluster database](/influxdb/cloud-dedicated/admin/databases/) in nanoseconds, if applicable
+        The retention period of the [cluster database](/influxdb3/cloud-dedicated/admin/databases/) in nanoseconds, if applicable
 
         If the retention period is not set or is set to 0, the database will have infinite retention
       type: integer
@@ -1623,7 +1623,7 @@ components:
       minimum: 1
     ClusterDatabasePartitionTemplate:
       description: |
-        A template for [partitioning](/influxdb/cloud-dedicated/admin/custom-partitions/) a cluster database.
+        A template for [partitioning](/influxdb3/cloud-dedicated/admin/custom-partitions/) a cluster database.
 
         Each template part is evaluated in sequence, concatinating the final
         partition key from the output of each part, delimited by the partition
@@ -1667,7 +1667,7 @@ components:
           * `time=2023-01-01, a=<long string>`                   -> `2023|<long string>#|!|!`
           * `time=2023-01-01, c=<long string>`                   -> `2023|!|!|<bucket ID for untruncated long string>`
 
-        When using the default [partitioning](/influxdb/cloud-dedicated/admin/custom-partitions/) template (YYYY-MM-DD) there is no
+        When using the default [partitioning](/influxdb3/cloud-dedicated/admin/custom-partitions/) template (YYYY-MM-DD) there is no
         encoding necessary, as the derived partition key contains a single part, and
         no reserved characters. [`TemplatePart::Bucket`] parts by definition will
         always be within the part length limit and contain no restricted characters
@@ -1769,7 +1769,7 @@ components:
             tagName: c
             numberOfBuckets: 10
     ClusterDatabaseTableName:
-      description: The name of the [cluster database](/influxdb/cloud-dedicated/admin/databases/) table
+      description: The name of the [cluster database](/influxdb3/cloud-dedicated/admin/databases/) table
       type: string
       examples:
         - TableOne
@@ -1782,15 +1782,15 @@ components:
         - Limited Access Token
         - Full Access Token
     DatabaseTokenResourceAllDatabases:
-      description: A resource value for a [database token](/influxdb/cloud-dedicated/admin/tokens/database/) permission that refers to all databases
+      description: A resource value for a [database token](/influxdb3/cloud-dedicated/admin/tokens/database/) permission that refers to all databases
       type: string
       enum:
         - '*'
     DatabaseTokenPermissionAction:
-      description: The action the [database token](/influxdb/cloud-dedicated/admin/tokens/database/) permission allows
+      description: The action the [database token](/influxdb3/cloud-dedicated/admin/tokens/database/) permission allows
       type: string
     DatabaseTokenPermissionResource:
-      description: The resource the [database token](/influxdb/cloud-dedicated/admin/tokens/database/) permission applies to
+      description: The resource the [database token](/influxdb3/cloud-dedicated/admin/tokens/database/) permission applies to
       anyOf:
         - $ref: '#/components/schemas/ClusterDatabaseName'
         - $ref: '#/components/schemas/DatabaseTokenResourceAllDatabases'
@@ -1814,7 +1814,7 @@ components:
         - action: write
           resource: '*'
     DatabaseTokenPermissions:
-      description: The list of permissions the [database token](/influxdb/cloud-dedicated/admin/tokens/database/) allows
+      description: The list of permissions the [database token](/influxdb3/cloud-dedicated/admin/tokens/database/) allows
       type: array
       items:
         $ref: '#/components/schemas/DatabaseTokenPermission'
@@ -1827,7 +1827,7 @@ components:
             resource: '*'
     DatabaseTokenCreatedAt:
       description: |
-        The date and time that the [database token](/influxdb/cloud-dedicated/admin/tokens/database/) was created
+        The date and time that the [database token](/influxdb3/cloud-dedicated/admin/tokens/database/) was created
 
         Uses RFC3339 format
       $ref: '#/components/schemas/DateTimeRfc3339'

--- a/types.gen.go
+++ b/types.gen.go
@@ -45,7 +45,7 @@ type ClusterDatabaseMaxTables = int32
 // ClusterDatabaseName The name of the cluster database
 type ClusterDatabaseName = string
 
-// ClusterDatabasePartitionTemplate A template for [partitioning](/influxdb/cloud-dedicated/admin/custom-partitions/) a cluster database.
+// ClusterDatabasePartitionTemplate A template for [partitioning](/influxdb3/cloud-dedicated/admin/custom-partitions/) a cluster database.
 //
 // Each template part is evaluated in sequence, concatinating the final
 // partition key from the output of each part, delimited by the partition
@@ -91,7 +91,7 @@ type ClusterDatabaseName = string
 //   - `time=2023-01-01, a=<long string>`                   -> `2023|<long string>#|!|!`
 //   - `time=2023-01-01, c=<long string>`                   -> `2023|!|!|<bucket ID for untruncated long string>`
 //
-// When using the default [partitioning](/influxdb/cloud-dedicated/admin/custom-partitions/) template (YYYY-MM-DD) there is no
+// When using the default [partitioning](/influxdb3/cloud-dedicated/admin/custom-partitions/) template (YYYY-MM-DD) there is no
 // encoding necessary, as the derived partition key contains a single part, and
 // no reserved characters. [`TemplatePart::Bucket`] parts by definition will
 // always be within the part length limit and contain no restricted characters
@@ -140,12 +140,12 @@ type ClusterDatabasePartitionTemplatePartTimeFormat struct {
 // ClusterDatabasePartitionTemplatePartTimeFormatType defines model for ClusterDatabasePartitionTemplatePartTimeFormat.Type.
 type ClusterDatabasePartitionTemplatePartTimeFormatType string
 
-// ClusterDatabaseRetentionPeriod The retention period of the [cluster database](/influxdb/cloud-dedicated/admin/databases/) in nanoseconds, if applicable
+// ClusterDatabaseRetentionPeriod The retention period of the [cluster database](/influxdb3/cloud-dedicated/admin/databases/) in nanoseconds, if applicable
 //
 // If the retention period is not set or is set to 0, the database will have infinite retention
 type ClusterDatabaseRetentionPeriod = int64
 
-// ClusterDatabaseTableName The name of the [cluster database](/influxdb/cloud-dedicated/admin/databases/) table
+// ClusterDatabaseTableName The name of the [cluster database](/influxdb3/cloud-dedicated/admin/databases/) table
 type ClusterDatabaseTableName = string
 
 // DatabaseTokenAccessToken The access token that can be used to authenticate query and write requests to the cluster
@@ -161,25 +161,25 @@ type DatabaseTokenDescription = string
 
 // DatabaseTokenPermission The description of the database token
 type DatabaseTokenPermission struct {
-	// Action The action the [database token](/influxdb/cloud-dedicated/admin/tokens/database/) permission allows
+	// Action The action the [database token](/influxdb3/cloud-dedicated/admin/tokens/database/) permission allows
 	Action *DatabaseTokenPermissionAction `json:"action,omitempty"`
 
-	// Resource The resource the [database token](/influxdb/cloud-dedicated/admin/tokens/database/) permission applies to
+	// Resource The resource the [database token](/influxdb3/cloud-dedicated/admin/tokens/database/) permission applies to
 	Resource *DatabaseTokenPermissionResource `json:"resource,omitempty"`
 }
 
-// DatabaseTokenPermissionAction The action the [database token](/influxdb/cloud-dedicated/admin/tokens/database/) permission allows
+// DatabaseTokenPermissionAction The action the [database token](/influxdb3/cloud-dedicated/admin/tokens/database/) permission allows
 type DatabaseTokenPermissionAction = string
 
-// DatabaseTokenPermissionResource The resource the [database token](/influxdb/cloud-dedicated/admin/tokens/database/) permission applies to
+// DatabaseTokenPermissionResource The resource the [database token](/influxdb3/cloud-dedicated/admin/tokens/database/) permission applies to
 type DatabaseTokenPermissionResource struct {
 	union json.RawMessage
 }
 
-// DatabaseTokenPermissions The list of permissions the [database token](/influxdb/cloud-dedicated/admin/tokens/database/) allows
+// DatabaseTokenPermissions The list of permissions the [database token](/influxdb3/cloud-dedicated/admin/tokens/database/) allows
 type DatabaseTokenPermissions = []DatabaseTokenPermission
 
-// DatabaseTokenResourceAllDatabases A resource value for a [database token](/influxdb/cloud-dedicated/admin/tokens/database/) permission that refers to all databases
+// DatabaseTokenResourceAllDatabases A resource value for a [database token](/influxdb3/cloud-dedicated/admin/tokens/database/) permission that refers to all databases
 type DatabaseTokenResourceAllDatabases string
 
 // DateTimeRfc3339 defines model for DateTimeRfc3339.
@@ -223,7 +223,7 @@ type CreateClusterDatabaseJSONBody struct {
 	// Name The name of the cluster database
 	Name ClusterDatabaseName `json:"name"`
 
-	// PartitionTemplate A template for [partitioning](/influxdb/cloud-dedicated/admin/custom-partitions/) a cluster database.
+	// PartitionTemplate A template for [partitioning](/influxdb3/cloud-dedicated/admin/custom-partitions/) a cluster database.
 	//
 	// Each template part is evaluated in sequence, concatinating the final
 	// partition key from the output of each part, delimited by the partition
@@ -267,14 +267,14 @@ type CreateClusterDatabaseJSONBody struct {
 	//   * `time=2023-01-01, a=<long string>`                   -> `2023|<long string>#|!|!`
 	//   * `time=2023-01-01, c=<long string>`                   -> `2023|!|!|<bucket ID for untruncated long string>`
 	//
-	// When using the default [partitioning](/influxdb/cloud-dedicated/admin/custom-partitions/) template (YYYY-MM-DD) there is no
+	// When using the default [partitioning](/influxdb3/cloud-dedicated/admin/custom-partitions/) template (YYYY-MM-DD) there is no
 	// encoding necessary, as the derived partition key contains a single part, and
 	// no reserved characters. [`TemplatePart::Bucket`] parts by definition will
 	// always be within the part length limit and contain no restricted characters
 	// so are also not percent-encoded and/or truncated.
 	PartitionTemplate *ClusterDatabasePartitionTemplate `json:"partitionTemplate,omitempty"`
 
-	// RetentionPeriod The retention period of the [cluster database](/influxdb/cloud-dedicated/admin/databases/) in nanoseconds, if applicable
+	// RetentionPeriod The retention period of the [cluster database](/influxdb3/cloud-dedicated/admin/databases/) in nanoseconds, if applicable
 	//
 	// If the retention period is not set or is set to 0, the database will have infinite retention
 	RetentionPeriod *ClusterDatabaseRetentionPeriod `json:"retentionPeriod,omitempty"`
@@ -288,7 +288,7 @@ type UpdateClusterDatabaseJSONBody struct {
 	// MaxTables The maximum number of tables for the cluster database
 	MaxTables *ClusterDatabaseMaxTables `json:"maxTables,omitempty"`
 
-	// RetentionPeriod The retention period of the [cluster database](/influxdb/cloud-dedicated/admin/databases/) in nanoseconds, if applicable
+	// RetentionPeriod The retention period of the [cluster database](/influxdb3/cloud-dedicated/admin/databases/) in nanoseconds, if applicable
 	//
 	// If the retention period is not set or is set to 0, the database will have infinite retention
 	RetentionPeriod *ClusterDatabaseRetentionPeriod `json:"retentionPeriod,omitempty"`
@@ -296,10 +296,10 @@ type UpdateClusterDatabaseJSONBody struct {
 
 // CreateClusterDatabaseTableJSONBody defines parameters for CreateClusterDatabaseTable.
 type CreateClusterDatabaseTableJSONBody struct {
-	// Name The name of the [cluster database](/influxdb/cloud-dedicated/admin/databases/) table
+	// Name The name of the [cluster database](/influxdb3/cloud-dedicated/admin/databases/) table
 	Name ClusterDatabaseTableName `json:"name"`
 
-	// PartitionTemplate A template for [partitioning](/influxdb/cloud-dedicated/admin/custom-partitions/) a cluster database.
+	// PartitionTemplate A template for [partitioning](/influxdb3/cloud-dedicated/admin/custom-partitions/) a cluster database.
 	//
 	// Each template part is evaluated in sequence, concatinating the final
 	// partition key from the output of each part, delimited by the partition
@@ -343,7 +343,7 @@ type CreateClusterDatabaseTableJSONBody struct {
 	//   * `time=2023-01-01, a=<long string>`                   -> `2023|<long string>#|!|!`
 	//   * `time=2023-01-01, c=<long string>`                   -> `2023|!|!|<bucket ID for untruncated long string>`
 	//
-	// When using the default [partitioning](/influxdb/cloud-dedicated/admin/custom-partitions/) template (YYYY-MM-DD) there is no
+	// When using the default [partitioning](/influxdb3/cloud-dedicated/admin/custom-partitions/) template (YYYY-MM-DD) there is no
 	// encoding necessary, as the derived partition key contains a single part, and
 	// no reserved characters. [`TemplatePart::Bucket`] parts by definition will
 	// always be within the part length limit and contain no restricted characters
@@ -356,7 +356,7 @@ type CreateDatabaseTokenJSONBody struct {
 	// Description The description of the database token
 	Description DatabaseTokenDescription `json:"description"`
 
-	// Permissions The list of permissions the [database token](/influxdb/cloud-dedicated/admin/tokens/database/) allows
+	// Permissions The list of permissions the [database token](/influxdb3/cloud-dedicated/admin/tokens/database/) allows
 	Permissions *DatabaseTokenPermissions `json:"permissions,omitempty"`
 }
 
@@ -365,7 +365,7 @@ type UpdateDatabaseTokenJSONBody struct {
 	// Description The description of the database token
 	Description *DatabaseTokenDescription `json:"description,omitempty"`
 
-	// Permissions The list of permissions the [database token](/influxdb/cloud-dedicated/admin/tokens/database/) allows
+	// Permissions The list of permissions the [database token](/influxdb3/cloud-dedicated/admin/tokens/database/) allows
 	Permissions *DatabaseTokenPermissions `json:"permissions,omitempty"`
 }
 


### PR DESCRIPTION
- Updated the InfluxDB v3 Management API Go client library to reflect changes in the documentation URLs. The changes primarily focus on updating the links to the new `influxdb3` path.
- Updated the OpenAPI spec URL in `README.md` to point to the new `influxdb3` path.